### PR TITLE
timeline_render shouldn't fallback to the default template for any error.

### DIFF
--- a/Twig/Extension/TimelineExtension.php
+++ b/Twig/Extension/TimelineExtension.php
@@ -61,7 +61,7 @@ class TimelineExtension extends \Twig_Extension
 
         try {
             return $this->twig->render($template, $parameters);
-        } catch (\Exception $e) {
+        } catch (\Twig_Error_Loader $e) {
             if (null !== $this->config['fallback']) {
                 return $this->twig->render($this->config['fallback'], $parameters);
             }


### PR DESCRIPTION
It should be triggered only when we can't load the correct template
