### PR TITLE
Support pagination for timelines for non-redid db_drivers

### DIFF
--- a/Entity/TimelineActionManager.php
+++ b/Entity/TimelineActionManager.php
@@ -116,4 +116,30 @@ class TimelineActionManager implements TimelineActionManagerInterface
 
         return $qb->getQuery()->getResult();
     }
+
+    /**
+     * {@inheritdoc}
+     * @param array $options
+     */
+    public function countTimeline(array $params, array $options = array())
+    {
+        if (!isset($params['subjectModel']) || !isset($params['subjectId'])) {
+            throw new \InvalidArgumentException('You have to define a "subjectModel" and a "subjectId" to pull data');
+        }
+
+        $status = isset($options['status']) ? $options['status'] : 'published';
+
+        $qb = $this->em->getRepository($this->timelineActionClass)->createQueryBuilder('ta');
+
+        $qb
+            ->select('count(ta)')
+            ->where('ta.subjectModel = :subjectModel')
+            ->andWhere('ta.subjectId = :subjectId')
+            ->andWhere('ta.statusCurrent = :status')
+            ->setParameter('subjectModel', $params['subjectModel'])
+            ->setParameter('subjectId', $params['subjectId'])
+            ->setParameter('status', $status);
+
+        return $qb->getQuery()->getSingleScalarResult();
+    }
 }

--- a/Manager.php
+++ b/Manager.php
@@ -108,6 +108,22 @@ class Manager
     }
 
     /**
+     * @param string $subjectModel subjectModel
+     * @param string $subjectId    subjectId
+     * @param array  $options      An array of options to give
+     *
+     * @return integer
+     */
+    public function countTimeline($subjectModel, $subjectId, $options)
+    {
+        $params = array(
+            'subjectModel' => $subjectModel,
+            'subjectId'    => $subjectId,
+        );
+        return $this->timelineActionManager->countTimeline($params, $options);
+    }
+
+    /**
      * That's all actions of the subject
      *
      * @param string $subjectModel The class of the subject

--- a/Model/TimelineActionManagerInterface.php
+++ b/Model/TimelineActionManagerInterface.php
@@ -32,6 +32,16 @@ interface TimelineActionManagerInterface
     public function getTimelineActionsForIds(array $ids);
 
     /**
+     * Get a count of timeline entries for a subject
+     *
+     * @param array $params  (subjectModel, subjectId)
+     * @param array $options (offset, limit, status)
+     *
+     * @return array
+     */
+    public function countTimeline(array $params, array $options = array());
+
+    /**
      * getTimeline of a subject
      *
      * @param array $params  (subjectModel, subjectId)

--- a/Pager/Subscriber/TimelineSubscriber.php
+++ b/Pager/Subscriber/TimelineSubscriber.php
@@ -40,10 +40,10 @@ class TimelineSubscriber implements EventSubscriberInterface
             $subjectId    = $token->subjectId;
             $context      = $token->context;
 
-            $options = array(
+            $options = array_merge($token->options, array(
                 'offset' => $event->getOffset(),
                 'limit'  => $event->getLimit(),
-            );
+            ));
 
             if ($token->getService() == TimelinePagerToken::SERVICE_TIMELINE) {
                 $event->count = $this->manager->countWallEntries($subjectClass, $subjectId, $context);
@@ -51,6 +51,9 @@ class TimelineSubscriber implements EventSubscriberInterface
             } elseif ($token->getService() == TimelinePagerToken::SERVICE_NOTIFICATION) {
                 $event->count = $this->unreadNotifications->countKeys($subjectClass, $subjectId, $context);
                 $event->items = $this->unreadNotifications->getTimelineActions($subjectClass, $subjectId, $context, $options);
+            } elseif ($token->getService() == TimelinePagerToken::SERVICE_SUBJECT_TIMELINE) {
+                $event->count = $this->manager->countTimeline($subjectClass, $subjectId, $options);
+                $event->items = $this->manager->getTimeline($subjectClass, $subjectId, $options);
             }
             $event->stopPropagation();
         }

--- a/Pager/TimelinePagerToken.php
+++ b/Pager/TimelinePagerToken.php
@@ -13,22 +13,26 @@ class TimelinePagerToken
     public $subjectClass;
     public $subjectId;
     public $context;
+    public $options;
 
-    CONST SERVICE_TIMELINE     = "timeline";
-    CONST SERVICE_NOTIFICATION = "notification";
+    CONST SERVICE_TIMELINE          = "timeline";
+    CONST SERVICE_SUBJECT_TIMELINE  = "subject_timeline";
+    CONST SERVICE_NOTIFICATION      = "notification";
 
     /**
      * @param string  $service      service
      * @param string  $subjectClass subjectClass
      * @param integer $subjectId    subjectId
      * @param string  $context      context
+     * @param array   $options      options
      */
-    public function __construct($service, $subjectClass, $subjectId, $context='GLOBAL')
+    public function __construct($service, $subjectClass, $subjectId, $context='GLOBAL',array $options = array())
     {
         $this->setService($service);
         $this->subjectClass = $subjectClass;
         $this->subjectId    = $subjectId;
         $this->context      = $context;
+        $this->options      = $options;
     }
 
     /**
@@ -36,8 +40,8 @@ class TimelinePagerToken
      */
     public function setService($service)
     {
-        if (!in_array($service, array(self::SERVICE_TIMELINE, self::SERVICE_NOTIFICATION))) {
-            throw new \InvalidArgumentException('Invalid service, timeline or notification, nothing else');
+        if (!in_array($service, array(self::SERVICE_TIMELINE, self::SERVICE_SUBJECT_TIMELINE, self::SERVICE_NOTIFICATION))) {
+            throw new \InvalidArgumentException('Invalid service, timeline subject_timeline, or notification, nothing else');
         }
 
         $this->service = $service;

--- a/Redis/TimelineActionManager.php
+++ b/Redis/TimelineActionManager.php
@@ -100,4 +100,15 @@ class TimelineActionManager implements TimelineActionManagerInterface
     {
         throw new \Exception('This method is not supported for redis db_driver');
     }
+
+    /**
+     * {@inheritDoc}
+     * Not supported on Redis
+     * @throw \Exception
+     */
+    public function countTimeline(array $params, array $options = array())
+    {
+        throw new \Exception('This method is not supported for redis db_driver');
+    }
+
 }

--- a/Resources/doc/pagination.markdown
+++ b/Resources/doc/pagination.markdown
@@ -17,6 +17,7 @@ class Controller
         $page       = $this->get('request')->get('page', 1);
         $maxPerPage = 10;
 
+        // Paginate Notifications
         // \User is the class of User and 1337 is id
         $notifications = $paginator->paginate(
             new TimelinePagerToken(TimelinePagerToken::SERVICE_NOTIFICATION, '\User', 1337),
@@ -24,9 +25,18 @@ class Controller
             $maxPerPage
         );
 
+        // Paginate wall for a subject
         // \User is the class of User and 1337 is id
         $timeline = $paginator->paginate(
             new TimelinePagerToken(TimelinePagerToken::SERVICE_TIMELINE, '\User', 1337),
+            $page,
+            $maxPerPage
+        );
+
+        // Paginate timeline for a subject
+        // \User is the class of User and 1337 is id
+        $timeline = $paginator->paginate(
+            new TimelinePagerToken(TimelinePagerToken::SERVICE_SUBJECT_TIMELINE, '\User', 1337),
             $page,
             $maxPerPage
         );


### PR DESCRIPTION
Fixes #38.
- Adds new TimelinePaginationToken constant 'SUBJECT_TIMELINE' rather than renaming 'TIMELINE' to 'WALL' for BC
- Adds new method signature to TimelineActionManagerInterface: countTimeline()
- Updated docs to show new usage

You may want to include your own commentary in the docs as to the need to use a slightly odd constant name…
