### PR TITLE
Fix for ORM Provider's getWall to properly query Actions

### DIFF
--- a/Provider/Doctrine/ORMProvider.php
+++ b/Provider/Doctrine/ORMProvider.php
@@ -108,7 +108,8 @@ class ORMProvider extends AbstractDoctrineProvider
 
         $qb = $this->getBaseQueryBuilder($type, $context, $params['subjectModel'], $params['subjectId']);
 
-        $qb->leftJoin('t.timelineAction', 'ta')
+        $qb->addSelect('ta')
+            ->leftJoin('t.timelineAction', 'ta')
             ->orderBy('ta.createdAt', 'DESC')
             ->setFirstResult($offset)
             ->setMaxResults($limit);


### PR DESCRIPTION
Forgot to add a 'select' for the actions table to the timeline query.

This omission was causing each action to be lazy-loaded rather than returned from the original query.
