### PR TITLE
Make DataHydrator work with entity listener

### DIFF
--- a/Filter/DataHydrator/Entry.php
+++ b/Filter/DataHydrator/Entry.php
@@ -52,8 +52,12 @@ class Entry
     public function buildReference($name)
     {
         $getSubjectMethod = sprintf('get%s', Container::camelize($name));
-        // if object is already setted, we have not to continue
-        if (null !== $this->timelineAction->{$getSubjectMethod}()) {
+
+        // if object is already set (and not an non-inited proxy), we don't need to continue
+        $object = $this->timelineAction->{$getSubjectMethod}();
+        if (null !== $object
+            AND (!$object instanceof \Doctrine\Common\Persistence\Proxy OR $object->__isInitialized())
+        ) {
             return;
         }
 


### PR DESCRIPTION
Adds a check to see if the objects associated with an action are uninitialized Doctrine [`Proxy`](https://github.com/doctrine/common/blob/2.2/lib/Doctrine/Common/Persistence/Proxy.php) objects. If so, it continues to hydrate (instead of assuming they're fully-resolved objects).

This allows the `DataHydrator` to work in conjunction with the `EntityListener`.
