### PR TITLE
Fixed : don't throw unappropriate exception calling findComponents method

### DIFF
--- a/Driver/ORM/ActionManager.php
+++ b/Driver/ORM/ActionManager.php
@@ -131,15 +131,22 @@ class ActionManager extends AbstractActionManager implements ActionManagerInterf
      */
     public function findComponents(array $hashes)
     {
+        $result = array();
+
         $qb = $this->getComponentRepository()
             ->createQueryBuilder('c');
 
-        return $qb
-            ->where(
-                $qb->expr()->in('c.hash', $hashes)
-            )
-            ->getQuery()
-            ->getResult();
+        if (count($hashes) > 0)
+        {
+            $result = $qb
+                ->where(
+                    $qb->expr()->in('c.hash', $hashes)
+                )
+                ->getQuery()
+                ->getResult();
+        }
+
+        return $result;
     }
 
     protected function getQueryBuilderForSubject(ComponentInterface $subject)


### PR DESCRIPTION
For the ORM driver, when the database was empty, findComponents method was throwing an exception as the in() query was trying to express som in() about empty hashes array.
