### PR TITLE
Try to resolve model and id in multiple managers

### DIFF
--- a/DependencyInjection/Compiler/AddRegistryCompilerPass.php
+++ b/DependencyInjection/Compiler/AddRegistryCompilerPass.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Spy\TimelineBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * AddRegistryCompilerPass
+ *
+ * @uses CompilerPassInterface
+ * @author Emmanuel Vella <vella.emmanuel@gmail.com>
+ */
+class AddRegistryCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach (array('orm', 'odm') as $driver) {
+            $id = sprintf('spy_timeline.action_manager.%s', $driver);
+
+            if ($container->hasDefinition($id)) {
+                $actionManager = $container->getDefinition($id);
+
+                foreach (array('doctrine', 'doctrine_mongodb') as $id) {
+                    if ($container->hasDefinition($id)) {
+                        $registry = $container->getDefinition($id);
+                        $actionManager->addMethodCall('addRegistry', array($registry));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SpyTimelineBundle.php
+++ b/SpyTimelineBundle.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Spy\TimelineBundle\DependencyInjection\Compiler\AddSpreadCompilerPass;
 use Spy\TimelineBundle\DependencyInjection\Compiler\AddFilterCompilerPass;
+use Spy\TimelineBundle\DependencyInjection\Compiler\AddRegistryCompilerPass;
 
 /**
  * SpyTimelineBundle
@@ -22,6 +23,7 @@ class SpyTimelineBundle extends Bundle
     {
         $container->addCompilerPass(new AddSpreadCompilerPass());
         $container->addCompilerPass(new AddFilterCompilerPass());
+        $container->addCompilerPass(new AddRegistryCompilerPass());
     }
 
 }


### PR DESCRIPTION
In the method `resolveModelAndIdentifier`, we try to get the class metadata from the current manager. If the class is managed by another manager, it will throws an exception.

With this PR, the class manager is now searched through the doctrine registries (orm and mongodb), so we can now get the metadata even if working with different managers.
