### PR TITLE
Set action manager deployer dependency dynamically

### DIFF
--- a/DependencyInjection/SpyTimelineExtension.php
+++ b/DependencyInjection/SpyTimelineExtension.php
@@ -62,6 +62,13 @@ class SpyTimelineExtension extends Extension
         $container->setAlias('spy_timeline.timeline_manager', $timelineManager);
         $container->setAlias('spy_timeline.action_manager', $actionManager);
 
+        if ('immediate' === $config['spread']['delivery']) {
+            $container
+                ->getDefinition($actionManager)
+                ->addMethodCall('setDeployer', array(new Reference('spy_timeline.spread.deployer')))
+            ;
+        }
+
         // pager
 
         if (isset($config['paginator']) && !empty($config['paginator'])) {

--- a/Resources/config/services/driver/odm.xml
+++ b/Resources/config/services/driver/odm.xml
@@ -24,9 +24,6 @@
             <argument>%spy_timeline.class.action%</argument>
             <argument>%spy_timeline.class.component%</argument>
             <argument>%spy_timeline.class.action_component%</argument>
-            <call method="setDeployer">
-                <argument type="service" id="spy_timeline.spread.deployer" />
-            </call>
         </service>
 
         <service id="spy_timeline.pager.odm" class="%spy_timeline.pager.odm.class%" public="false" />

--- a/Resources/config/services/driver/orm.xml
+++ b/Resources/config/services/driver/orm.xml
@@ -25,9 +25,6 @@
             <argument>%spy_timeline.class.action%</argument>
             <argument>%spy_timeline.class.component%</argument>
             <argument>%spy_timeline.class.action_component%</argument>
-            <call method="setDeployer">
-                <argument type="service" id="spy_timeline.spread.deployer" />
-            </call>
         </service>
 
         <service id="spy_timeline.pager.orm" class="%spy_timeline.pager.orm.class%" public="false" />

--- a/Resources/config/services/driver/redis.xml
+++ b/Resources/config/services/driver/redis.xml
@@ -26,9 +26,6 @@
             <argument>%spy_timeline.class.action%</argument>
             <argument>%spy_timeline.class.component%</argument>
             <argument>%spy_timeline.class.action_component%</argument>
-            <call method="setDeployer">
-                <argument type="service" id="spy_timeline.spread.deployer" />
-            </call>
         </service>
 
         <service id="spy_timeline.pager.redis" class="%spy_timeline.pager.redis.class%" public="false">


### PR DESCRIPTION
This injects the deployer in the action manager only if necessary (ie if spread devliery is immediate).

In my (specific) case, this helps to solve a circular reference and is BC.
