### PR TITLE
composer requires twig-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require-dev": {
         "atoum/atoum-bundle": "dev-master",
         "doctrine/orm": "2.*",
-        "symfony/console": "2.*"
+        "symfony/console": "2.*",
+        "symfony/twig-bundle": "2.*"
     },
     "suggest": {
         "symfony/console": "List spreads and deploy timelines via a command",


### PR DESCRIPTION
While forking this repo I noticed I didn't have access to the twig files, 
it's not required in the framework bundle so I added the dependency
