### PR TITLE
Fix ParameterNotFound Exception

### DIFF
--- a/DependencyInjection/Compiler/AddLocatorCompilerPass.php
+++ b/DependencyInjection/Compiler/AddLocatorCompilerPass.php
@@ -40,8 +40,12 @@ class AddLocatorCompilerPass implements CompilerPassInterface
     private function getLocatorDefinitionsFromParameter(ContainerBuilder $container)
     {
         $data = array();
+        $locatorServiceIdArray = array();
+
         //get the config array from the parameter.
-        $locatorServiceIdArray = $container->getParameter('spy_timeline.filter.data_hydrator.locators_config');
+        if (!$container->hasParameter('spy_timeline.filter.data_hydrator.locators_config')) {
+            $locatorServiceIdArray = $container->getParameter('spy_timeline.filter.data_hydrator.locators_config');
+        }
 
         if ($this->validConfigLocators($locatorServiceIdArray)) {
             foreach ($locatorServiceIdArray as $serviceId) {


### PR DESCRIPTION
If no data hydrators are defined, i get a ParameterNotFound Exception.

```
  [Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException]
  You have requested a non-existent parameter "spy_timeline.filter.data_hydrator.locators_config". Did you mean this: "spy_timeline.filter.data_hydrator.class"?

```
