### PR TITLE
Added exception message for spy_timeline:deploy

### DIFF
--- a/Command/DeployActionCommand.php
+++ b/Command/DeployActionCommand.php
@@ -50,6 +50,9 @@ class DeployActionCommand extends ContainerAwareCommand
                 $output->writeln(sprintf('<comment>Deploy action %s</comment>', $action->getId()));
             } catch (\Exception $e) {
                 $message = sprintf('[TIMELINE] Error during deploy action %s', $action->getId());
+                if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
+                    $message .= sprintf('%s: %s', $message, $e->getMessage());
+                }
 
                 $container->get('logger')->crit($message);
                 $output->writeln(sprintf('<error>%s</error>', $message));


### PR DESCRIPTION
Added exception message for `spy_timeline:deploy` when verbosity level is at least 2 (command executed with `-v` option) and errors occurred.

`$ app/console spy_timeline:deploy -v`

**Before:**
`[TIMELINE] Error during deploy action 123`

**After:**
`[TIMELINE] Error during deploy action 123: The exception message`

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
