### PR TITLE
Update basic_example.markdown

### DIFF
--- a/Resources/doc/basic_example.markdown
+++ b/Resources/doc/basic_example.markdown
@@ -63,7 +63,7 @@ class MySpread implements SpreadInterface
     public function supports(ActionInterface $action)
     {
         // here you define what actions you want to support, you have to return a boolean.
-        if ($action->getSubject()->getName() == "ChuckNorris") {
+        if ($action->getSubject()->getIdentifier() == "chucknorris") {
             return true;
         }
 


### PR DESCRIPTION
the $action->getSubject->getName() is always empty because the $subject was created by action manager in step one and the its $name attribute had never been set.
After tracing source code in Spy\TimelineBundle\Driver\ODM\ActionManager, the effected attribute should be $identifier.
