### PR TITLE
Added support for extra user variables in timeline_render()

### DIFF
--- a/Resources/doc/basic_example.markdown
+++ b/Resources/doc/basic_example.markdown
@@ -122,6 +122,14 @@ In your template .twig:
 {% endfor %}
 ```
 
+If you need, custom vars can also be passed to template as 3rd argument:
+
+```twig
+{% for action in coll %}
+    {{ timeline_render(action, null, { 'some_var': some_value }) }}
+    {{ i18n_timeline_render(timeline, 'en', { 'some_var': some_value }) }}
+{% endfor
+
 Look at [renderer](https://github.com/stephpy/TimelineBundle/blob/master/Resources/doc/renderer.markdown) to see how to define a path to store verbs.
 
 If you have any questions, feel free to create an issue or contact us.

--- a/Resources/doc/renderer.markdown
+++ b/Resources/doc/renderer.markdown
@@ -16,11 +16,11 @@ render:
 # This will try to call "AcmeBundle:Timeline:**verb**.html.twig
 # If exception, it return the fallback defined on config
 
-{{ timeline_render(entry, "your template") }}
+{{ timeline_render(entry, "your template", { 'some_var': some_value }) }}
 # This will try to call "your template"
 # If exception, it return the fallback defined on config
 
-{{ i18n_timeline_render(entry, "en") }}
+{{ i18n_timeline_render(entry, "en", { 'some_var': some_value }) }}
 # This will try to call "AcmeBundle:Timeline:**verb**.en.html.twig
 # If exception, it return the i18n fallback defined on config and then on global fallback
 ```

--- a/Twig/Extension/TimelineExtension.php
+++ b/Twig/Extension/TimelineExtension.php
@@ -361,10 +361,11 @@ class TimelineExtension extends \Twig_Extension
     /**
      * @param object      $action What Action to render
      * @param string|null $locale Locale of the template
+     * @param array       $variables Additional variables to pass to templates
      *
      * @return string
      */
-    public function renderLocalizedTimeline($action, $locale = null)
+    public function renderLocalizedTimeline($action, $locale = null, array $variables = array())
     {
         $action = $this->resolveAction($action, __METHOD__);
 
@@ -374,9 +375,9 @@ class TimelineExtension extends \Twig_Extension
 
         $template = $this->getDefaultLocalizedTemplate($action, $locale);
 
-        $parameters = array(
+        $parameters = array_merge($variables, array(
             'timeline' => $action,
-        );
+        ));
 
         try {
             return $this->twig->render($template, $parameters);


### PR DESCRIPTION
Added support for extra user variables in `timeline_render()` Twig extension via 3rd argument.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

TODO: 
- [x] Update documentation
