### PR TITLE
Fixed calling wrong doctrine method

### DIFF
--- a/Driver/ODM/ActionManager.php
+++ b/Driver/ODM/ActionManager.php
@@ -77,7 +77,7 @@ class ActionManager extends AbstractActionManager implements ActionManagerInterf
             ->field('model')->equals($resolvedComponentData->getModel())
             ->field('identifier')->equals($resolvedComponentData->getIdentifier())
             ->getQuery()
-            ->getSingleResult()
+            ->getOneOrNullResult()
         ;
 
         if ($component) {
@@ -99,7 +99,7 @@ class ActionManager extends AbstractActionManager implements ActionManagerInterf
             ->createQueryBuilder('c')
             ->field('hash')->equals($hash)
             ->getQuery()
-            ->getSingleResult()
+            ->getOneOrNullResult()
         ;
     }
 

--- a/Driver/ORM/TimelineManager.php
+++ b/Driver/ORM/TimelineManager.php
@@ -97,11 +97,13 @@ class TimelineManager extends AbstractTimelineManager implements TimelineManager
             ->andWhere('t.action = :action')
             ->setParameter('action', $actionId)
             ->getQuery()
-            ->getSingleResult()
+            ->getOneOrNullResult()
         ;
 
-        $this->objectManager->remove($timeline);
-        // $manager->flush() handled by flush() method
+        if ($timeline) {
+            $this->objectManager->remove($timeline);
+            // $manager->flush() handled by flush() method
+        }
     }
 
     /**


### PR DESCRIPTION
According to the phpdoc, the methods could return a `null` response.

The used `getSingleResult` method will throw an exception, if there was no or more than one result which is wrong. http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/dql-doctrine-query-language.html#query-result-formats