### PR TITLE
Fixed fatal error in dependency injection config

### DIFF
--- a/DependencyInjection/SpyTimelineExtension.php
+++ b/DependencyInjection/SpyTimelineExtension.php
@@ -105,7 +105,7 @@ class SpyTimelineExtension extends Extension
 
         // notifiers
         $notifiers  = $config['notifiers'];
-        $definition = new Reference($config['spread']['deployer']);
+        $definition = $container->getDefinition($config['spread']['deployer']);
 
         foreach ($notifiers as $notifier) {
             $definition->addMethodCall('addNotifier', array(new Reference($notifier)));


### PR DESCRIPTION
`$definition->addMethodCall(...)` on L111 results in `Fatal error: Call to undefined method Symfony\Component\DependencyInjection\Reference::addMethodCall()`. This is because `$definition` is `Reference` type, though it should be `Definition` type which has the `addMethodCall` method

see
https://github.com/stephpy/timeline-bundle/commit/ff9c3e740887e39d21b7e7521b589728d590a98c#commitcomment-21808406
for more details