### PR TITLE
Multiple spread classes failure to load

### DIFF
--- a/DependencyInjection/Compiler/AddSpreadCompilerPass.php
+++ b/DependencyInjection/Compiler/AddSpreadCompilerPass.php
@@ -23,9 +23,10 @@ class AddSpreadCompilerPass implements CompilerPassInterface
         }
 
         krsort($spreadByPriority);
+        $spreadByPriority = call_user_func_array('array_merge', $spreadByPriority);
 
         foreach ($spreadByPriority as $spreads) {
-            $spreadDeployer->addMethodCall('addSpread', $spreads);
+            $spreadDeployer->addMethodCall('addSpread', [$spreads]);
         }
     }
 }


### PR DESCRIPTION
Multiple spread classes will fail to be loaded into the deployer due to improper code.

Expected compiler pass result:
 $instance->addSpread(spread1);
 $instance->addSpread(spread2);
...

Current compiler pass:
$instance->addSpread(spread1,spread2,...)